### PR TITLE
Whitelisted offhand-slot 45

### DIFF
--- a/src/org/inventivetalent/mapmanager/DefaultMapWrapper.java
+++ b/src/org/inventivetalent/mapmanager/DefaultMapWrapper.java
@@ -138,7 +138,7 @@ class DefaultMapWrapper implements MapWrapper {
 			}
 
 			//Adjust the slot ID
-			if (slot < 9) { slot += 36; } else if (slot > 35) { slot = 8 - (slot - 36); }
+			if (slot < 9) { slot += 36; } else if (slot > 35 && slot != 45) { slot = 8 - (slot - 36); }
 
 			try {
 				if (PacketPlayOutSlotConstructorResolver == null) {


### PR DESCRIPTION
As mentioned in #27 and requested on Discord I've "whitelisted" slot 45 (according to [wiki.vg](https://wiki.vg/File:Inventory-slots.png)) so you can now use the offhand slot. Tested with 1.9.2.