### PR TITLE
Reverted building on Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.9</source>
-                    <target>1.9</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This causes the plugin to fail loading on Java 8.

If you want to drop Java 8 support, just update to Java 11 and mention it on the plugin page. Now you drop Java 8 support but still update to an old version. :P